### PR TITLE
Always call `bar` when item is ready to play

### DIFF
--- a/PRXPlayer.m
+++ b/PRXPlayer.m
@@ -825,10 +825,10 @@ static void * const PRXPlayerAVPlayerCurrentItemBufferEmptyContext = (void*)&PRX
                                                                                 [_self didObserveSoftBoundaryTime];
                                                                               }];
 
-        [self bar];
       });
     });
   }
+  [self bar];
 }
 
 - (void)mediaPlayerCurrentItemFailedToBecomeReadyToPlay {


### PR DESCRIPTION
Streaming AVPlayerItems will not have a `duration`, but we should still
start playing them when they indicate that they are ready to play. This
change leaves the duration setting code only to items with a valid
duration, but moves the call to `bar` so that it is always called when
an item is ready.
