### PR TITLE
Fix races by separating observation and assignment

### DIFF
--- a/PRXPlayer_private.h
+++ b/PRXPlayer_private.h
@@ -28,7 +28,8 @@
 
 @interface PRXPlayer ()
 
-+ (dispatch_queue_t)sharedQueue;
++ (dispatch_queue_t)sharedObserverQueue;
++ (dispatch_queue_t)sharedAssignmentQueue;
 
 @property (nonatomic, strong, readonly) Reachability *reach;
 @property (nonatomic, strong) AVPlayer *player;


### PR DESCRIPTION
Prior to this fix, both assignment of a new `AVPlayer` object to the
`player` property and all observations, including those from periodic
time observers, occurred on the same private queue. This led to a small
chance for a race condition on assignment of a new player, since any
in-flight periodic time observer messages need to be cleared after the
observations on the old player have been removed but before the player
is deallocated. The way this was implemented allowed for multiple player
assignments to queue up waiting for the observer messages to clear, and
then colliding into each other resulting in players being replaced (and
thus deallocated) before they are fully initialized.

This patch removes the chance for this race by introducing a new,
separate queue that can be used for assignments, independent of the
queue used for observations. In theory, this should prevent the race
condition from occurring.
